### PR TITLE
add --yarn flag and use npm by default

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -7,10 +7,11 @@ You can pass flags for each of the options.
 | Flag                     | Possible Values                | Action                                         |
 | ------------------------ | ------------------------------ | ---------------------------------------------- |
 | `--jh-dir`               | backend, ../backend            | The JHipster app's directory                   |
-| `--detox`                | true, false                    | Enables Detox E2E tests                     |
+| `--detox`                | true, false                    | Enables Detox E2E tests                        |
 | `--skip-git`             |                                | Skips git init                                 |
 | `--skip-lint`            |                                | Skips `standard` initialization (linting)      |
 | `--react-native-version` | 0.60.0                         | Install specific React Native version          |
+| `--yarn                ` |                                | Uses yarn in place of npm when generating      |
 
 #### JDL App Generation
 

--- a/src/boilerplate/index.js
+++ b/src/boilerplate/index.js
@@ -58,6 +58,14 @@ async function install (context) {
   let jhipsterConfig
   let jhipsterDirectory
 
+  // does the user want to use yarn?
+  let useNpm = !parameters.options.yarn
+  // `npm i` fails due to symlinks, so if the developer is using this boilerplate from a local directory, yarn is forced
+  if (context.parameters.options.boilerplate !== 'ignite-jhipster' && context.parameters.options.boilerplate !== 'jhipster') {
+    useNpm = false
+  }
+  ignite.useYarn = !useNpm
+
   // if the user is passing in JDL
   if (parameters.options.jdl) {
     print.info('Importing JDL')
@@ -120,7 +128,8 @@ async function install (context) {
   // attempt to install React Native or die trying
   const rnInstall = await reactNative.install({
     name,
-    version: getReactNativeVersion(context)
+    version: getReactNativeVersion(context),
+    useNpm: useNpm
   })
   if (rnInstall.exitCode > 0) process.exit(rnInstall.exitCode)
 
@@ -183,7 +192,7 @@ async function install (context) {
     spinner.text = `▸ installing dependencies`
     spinner.start()
     // install any missing dependencies
-    await system.run('yarn', { stdio: 'ignore' })
+    await system.run(useNpm ? 'npm i' : 'yarn', { stdio: 'ignore' })
     spinner.succeed(`dependencies installed`)
   }
   // pass long the debug flag if we're running in that mode

--- a/src/boilerplate/index.js
+++ b/src/boilerplate/index.js
@@ -60,10 +60,6 @@ async function install (context) {
 
   // does the user want to use yarn?
   let useNpm = !parameters.options.yarn
-  // `npm i` fails due to symlinks, so if the developer is using this boilerplate from a local directory, yarn is forced
-  if (context.parameters.options.boilerplate !== 'ignite-jhipster' && context.parameters.options.boilerplate !== 'jhipster') {
-    useNpm = false
-  }
   ignite.useYarn = !useNpm
 
   // if the user is passing in JDL
@@ -286,6 +282,10 @@ async function install (context) {
   print.info(print.colors.bold(`  cd ${name}`))
   print.info(print.colors.bold('  ignite generate'))
   print.info('')
+  if (useNpm && context.parameters.options.boilerplate !== 'ignite-jhipster' && context.parameters.options.boilerplate !== 'jhipster') {
+    print.warning('NOTE: Using local ignite-jhipster, removing `.git` folder from `node_modules/ignite-jhipster` to prevent issues with `npm i`')
+    await rimraf.sync('../node_modules/ignite-jhipster/.git')
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
I removed the one `yarn` command and made using `yarn` configurable.  It now uses `npm` by default, and you can use `yarn` with the `--yarn` flag

Fix #77